### PR TITLE
Refactored by Sourcery

### DIFF
--- a/agents/training.py
+++ b/agents/training.py
@@ -81,9 +81,9 @@ class Trainer(object):
       agent.replay_memory.save()
 
   def reset_target_network(self, session, step):
-    if self.reset_op:
-      if step > 0 and step % self.config.target_network_update_period == 0:
-        session.run(self.reset_op)
+    if (self.reset_op and step > 0
+        and step % self.config.target_network_update_period == 0):
+      session.run(self.reset_op)
 
   def train_batch(self, session, replay_memory, step):
     fetches = [self.global_step, self.train_op] + self.summary.operation(step)

--- a/atari/atari.py
+++ b/atari/atari.py
@@ -44,7 +44,7 @@ class Atari(object):
     if self.render: self.env.render()
     self.frames = []
 
-    for i in range(np.random.randint(self.input_frames, self.max_noops + 1)):
+    for _ in range(np.random.randint(self.input_frames, self.max_noops + 1)):
       frame, reward_, done, _ = self.env.step(0)
       if self.render: self.env.render()
 

--- a/networks/factory.py
+++ b/networks/factory.py
@@ -116,17 +116,16 @@ class NetworkFactory(object):
     return self.summary
 
   def create_reset_target_network_op(self):
-    if self.policy_nets and self.target_nets:
-      policy_variables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                           self.policy_scope.name)
-      target_variables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
-                                           self.target_scope.name)
-
-      with tf.name_scope('reset_target_network'):
-        copy_ops = []
-        for from_var, to_var in zip(policy_variables, target_variables):
-          name = 'reset_' + to_var.name.split('/', 1)[1][:-2].replace('/', '_')
-          copy_ops.append(tf.assign(to_var, from_var, name=name))
-        return tf.group(*copy_ops)
-    else:
+    if not (self.policy_nets and self.target_nets):
       return None
+    policy_variables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                         self.policy_scope.name)
+    target_variables = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                         self.target_scope.name)
+
+    with tf.name_scope('reset_target_network'):
+      copy_ops = []
+      for from_var, to_var in zip(policy_variables, target_variables):
+        name = 'reset_' + to_var.name.split('/', 1)[1][:-2].replace('/', '_')
+        copy_ops.append(tf.assign(to_var, from_var, name=name))
+      return tf.group(*copy_ops)

--- a/networks/inputs.py
+++ b/networks/inputs.py
@@ -100,11 +100,7 @@ class OffsetInput(object):
 
 class RequiredFeeds(object):
   def __init__(self, placeholder=None, time_offsets=0, feeds=None):
-    if feeds:
-      self.feeds = feeds
-    else:
-      self.feeds = {}
-
+    self.feeds = feeds if feeds else {}
     if placeholder is None:
       return
 

--- a/util/util.py
+++ b/util/util.py
@@ -13,7 +13,7 @@ def run_directory(config):
     if os.path.isdir(dir):
       runs = [child[4:] for child in os.listdir(dir) if child[:4] == 'run_']
       if runs:
-        return max([int(run) for run in runs])
+        return max(int(run) for run in runs)
 
     return 0
 


### PR DESCRIPTION
Thanks for starring [sourcery-ai/sourcery](https://github.com/sourcery-ai/sourcery) ✨ 🌟 ✨

Here's your pull request refactoring your most popular Python repo.

If you want Sourcery to refactor all your Python repos and incoming pull requests [install our bot](https://github.com/apps/sourcery-ai/installations/new).

### Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.

## Summary by Sourcery

Refine target network reset logic and simplify auxiliary utilities for cleaner, more Pythonic training code.

Bug Fixes:
- Ensure target network reset operation returns None explicitly when policy or target networks are missing.

Enhancements:
- Simplify conditional logic in target network reset operations to improve readability.
- Condense reset scheduling condition in the training loop into a single predicate.
- Use a default empty dict for required feeds when none is provided.
- Replace unused loop variable with underscore in Atari environment reset for clarity.
- Simplify max computation when finding the previous run ID.